### PR TITLE
paginate map function can read `response.data[namespaceKey]` for name spaced endpoints

### DIFF
--- a/src/normalize-paginated-list-response.ts
+++ b/src/normalize-paginated-list-response.ts
@@ -56,8 +56,8 @@ export function normalizePaginatedListResponse(
   delete response.data.total_count;
 
   const namespaceKey = Object.keys(response.data)[0];
-
-  response.data = response.data[namespaceKey];
+  const data = response.data[namespaceKey];
+  response.data = data;
 
   if (typeof incompleteResults !== "undefined") {
     response.data.incomplete_results = incompleteResults;
@@ -68,4 +68,13 @@ export function normalizePaginatedListResponse(
   }
 
   response.data.total_count = totalCount;
+
+  Object.defineProperty(response.data, namespaceKey, {
+    get() {
+      octokit.log.warn(
+        `[@octokit/paginate-rest] "response.data.${namespaceKey}" is deprecated for "GET ${path}". Get the results directly from "response.data"`
+      );
+      return Array.from(data);
+    }
+  });
 }

--- a/test/paginate.test.ts
+++ b/test/paginate.test.ts
@@ -453,6 +453,49 @@ describe("pagination", () => {
       });
   });
 
+  it(".paginate() sets response[namespacekey] for map function when results are namespaced", () => {
+    const result = {
+      total_count: 1,
+      incomplete_results: false,
+      items: [
+        {
+          id: "123"
+        }
+      ]
+    };
+
+    const query = encodeURIComponent(
+      "repo:web-platform-tests/wpt is:pr is:open updated:>2019-02-26"
+    );
+    const mock = fetchMock
+      .sandbox()
+      .get(`https://api.github.com/search/issues?q=${query}&per_page=1`, {
+        body: result
+      });
+
+    const octokit = new TestOctokit({
+      request: {
+        fetch: mock
+      }
+    });
+
+    return octokit.paginate<typeof result, undefined>(
+      "GET /search/issues",
+      {
+        q: "repo:web-platform-tests/wpt is:pr is:open updated:>2019-02-26",
+        per_page: 1,
+        headers: {
+          "accept-encoding": ""
+        }
+      },
+      response => {
+        // @ts-ignore
+        expect(response.data.items).toStrictEqual([{ id: "123" }]);
+        return [];
+      }
+    );
+  });
+
   it("does not paginate non-paginated response with total_count property", () => {
     const result = {
       state: "success",


### PR DESCRIPTION
fixes #9