### PR TITLE
Workarounds for new actions endpoints

### DIFF
--- a/src/normalize-paginated-list-response.ts
+++ b/src/normalize-paginated-list-response.ts
@@ -23,13 +23,15 @@ import { Octokit } from "@octokit/core";
 
 import { OctokitResponse } from "./types";
 
-const REGEX_IS_SEARCH_PATH = /^\/search\//;
-const REGEX_IS_CHECKS_PATH = /^\/repos\/[^/]+\/[^/]+\/commits\/[^/]+\/(check-runs|check-suites)([^/]|$)/;
-const REGEX_IS_INSTALLATION_REPOSITORIES_PATH = /^\/installation\/repositories([^/]|$)/;
-const REGEX_IS_USER_INSTALLATIONS_PATH = /^\/user\/installations([^/]|$)/;
-const REGEX_IS_ACTIONS_SECRETS_PATH = /^\/repos\/[^/]+\/[^/]+\/actions\/secrets([^/]|$)/;
-const REGEX_IS_ACTIONS_WORKFLOWS_PATH = /^\/repos\/[^/]+\/[^/]+\/actions\/workflows(\/[^/]+\/runs)?([^/]|$)/;
-const REGEX_IS_ACTIONS_WORKFLOW_RUNS_PATH = /^\/repos\/[^/]+\/[^/]+\/actions\/runs(\/[^/]+\/(artifacts|jobs))?([^/]|$)/;
+const REGEX = [
+  /^\/search\//,
+  /^\/repos\/[^/]+\/[^/]+\/commits\/[^/]+\/(check-runs|check-suites)([^/]|$)/,
+  /^\/installation\/repositories([^/]|$)/,
+  /^\/user\/installations([^/]|$)/,
+  /^\/repos\/[^/]+\/[^/]+\/actions\/secrets([^/]|$)/,
+  /^\/repos\/[^/]+\/[^/]+\/actions\/workflows(\/[^/]+\/runs)?([^/]|$)/,
+  /^\/repos\/[^/]+\/[^/]+\/actions\/runs(\/[^/]+\/(artifacts|jobs))?([^/]|$)/
+];
 
 export function normalizePaginatedListResponse(
   octokit: Octokit,
@@ -37,17 +39,8 @@ export function normalizePaginatedListResponse(
   response: OctokitResponse<any>
 ) {
   const path = url.replace(octokit.request.endpoint.DEFAULTS.baseUrl, "");
-  if (
-    !REGEX_IS_SEARCH_PATH.test(path) &&
-    !REGEX_IS_CHECKS_PATH.test(path) &&
-    !REGEX_IS_INSTALLATION_REPOSITORIES_PATH.test(path) &&
-    !REGEX_IS_USER_INSTALLATIONS_PATH.test(path) &&
-    !REGEX_IS_ACTIONS_SECRETS_PATH.test(path) &&
-    !REGEX_IS_ACTIONS_WORKFLOWS_PATH.test(path) &&
-    !REGEX_IS_ACTIONS_WORKFLOW_RUNS_PATH.test(path)
-  ) {
-    return;
-  }
+  const responseNeedsNormalization = REGEX.find(regex => regex.test(path));
+  if (!responseNeedsNormalization) return;
 
   // keep the additional properties intact as there is currently no other way
   // to retrieve the same information.

--- a/src/normalize-paginated-list-response.ts
+++ b/src/normalize-paginated-list-response.ts
@@ -30,6 +30,7 @@ const REGEX_IS_USER_INSTALLATIONS_PATH = /^\/user\/installations/;
 const REGEX_IS_ACTIONS_ARTIFACTS_PATH = /^\/repos\/[^/]+\/[^/]+\/actions\/runs\/[^/]+\/artifacts/;
 const REGEX_IS_ACTIONS_SECRETS_PATH = /^\/repos\/[^/]+\/[^/]+\/actions\/secrets/;
 const REGEX_IS_ACTIONS_WORKFLOWS_PATH = /^\/repos\/[^/]+\/[^/]+\/actions\/workflows/;
+const REGEX_IS_ACTIONS_JOBS_FOR_WORKFLOW_RUN_PATH = /^\/repos\/[^/]+\/[^/]+\/actions\/runs\/[^/]+\/jobs/;
 
 export function normalizePaginatedListResponse(
   octokit: Octokit,
@@ -44,7 +45,8 @@ export function normalizePaginatedListResponse(
     !REGEX_IS_USER_INSTALLATIONS_PATH.test(path) &&
     !REGEX_IS_ACTIONS_ARTIFACTS_PATH.test(path) &&
     !REGEX_IS_ACTIONS_SECRETS_PATH.test(path) &&
-    !REGEX_IS_ACTIONS_WORKFLOWS_PATH.test(path)
+    !REGEX_IS_ACTIONS_WORKFLOWS_PATH.test(path) &&
+    !REGEX_IS_ACTIONS_JOBS_FOR_WORKFLOW_RUN_PATH.test(path)
   ) {
     return;
   }

--- a/src/normalize-paginated-list-response.ts
+++ b/src/normalize-paginated-list-response.ts
@@ -27,6 +27,7 @@ const REGEX_IS_SEARCH_PATH = /^\/search\//;
 const REGEX_IS_CHECKS_PATH = /^\/repos\/[^/]+\/[^/]+\/commits\/[^/]+\/(check-runs|check-suites)/;
 const REGEX_IS_INSTALLATION_REPOSITORIES_PATH = /^\/installation\/repositories/;
 const REGEX_IS_USER_INSTALLATIONS_PATH = /^\/user\/installations/;
+const REGEX_IS_ACTIONS_ARTIFACTS_PATH = /^\/repos\/[^/]+\/[^/]+\/actions\/runs\/[^/]+\/artifacts/;
 
 export function normalizePaginatedListResponse(
   octokit: Octokit,
@@ -38,7 +39,8 @@ export function normalizePaginatedListResponse(
     !REGEX_IS_SEARCH_PATH.test(path) &&
     !REGEX_IS_CHECKS_PATH.test(path) &&
     !REGEX_IS_INSTALLATION_REPOSITORIES_PATH.test(path) &&
-    !REGEX_IS_USER_INSTALLATIONS_PATH.test(path)
+    !REGEX_IS_USER_INSTALLATIONS_PATH.test(path) &&
+    !REGEX_IS_ACTIONS_ARTIFACTS_PATH.test(path)
   ) {
     return;
   }

--- a/src/normalize-paginated-list-response.ts
+++ b/src/normalize-paginated-list-response.ts
@@ -28,7 +28,8 @@ const REGEX_IS_CHECKS_PATH = /^\/repos\/[^/]+\/[^/]+\/commits\/[^/]+\/(check-run
 const REGEX_IS_INSTALLATION_REPOSITORIES_PATH = /^\/installation\/repositories/;
 const REGEX_IS_USER_INSTALLATIONS_PATH = /^\/user\/installations/;
 const REGEX_IS_ACTIONS_ARTIFACTS_PATH = /^\/repos\/[^/]+\/[^/]+\/actions\/runs\/[^/]+\/artifacts/;
-const REGEX_IS_ACTIONS_SECRETS_PATH = /^\/repos\/[^/]+\/[^/]+\/actions\/runs\/[^/]+\/artifacts/;
+const REGEX_IS_ACTIONS_SECRETS_PATH = /^\/repos\/[^/]+\/[^/]+\/actions\/secrets/;
+const REGEX_IS_ACTIONS_WORKFLOWS_PATH = /^\/repos\/[^/]+\/[^/]+\/actions\/workflows/;
 
 export function normalizePaginatedListResponse(
   octokit: Octokit,
@@ -42,7 +43,8 @@ export function normalizePaginatedListResponse(
     !REGEX_IS_INSTALLATION_REPOSITORIES_PATH.test(path) &&
     !REGEX_IS_USER_INSTALLATIONS_PATH.test(path) &&
     !REGEX_IS_ACTIONS_ARTIFACTS_PATH.test(path) &&
-    !REGEX_IS_ACTIONS_SECRETS_PATH.test(path)
+    !REGEX_IS_ACTIONS_SECRETS_PATH.test(path) &&
+    !REGEX_IS_ACTIONS_WORKFLOWS_PATH.test(path)
   ) {
     return;
   }

--- a/src/normalize-paginated-list-response.ts
+++ b/src/normalize-paginated-list-response.ts
@@ -28,6 +28,7 @@ const REGEX_IS_CHECKS_PATH = /^\/repos\/[^/]+\/[^/]+\/commits\/[^/]+\/(check-run
 const REGEX_IS_INSTALLATION_REPOSITORIES_PATH = /^\/installation\/repositories/;
 const REGEX_IS_USER_INSTALLATIONS_PATH = /^\/user\/installations/;
 const REGEX_IS_ACTIONS_ARTIFACTS_PATH = /^\/repos\/[^/]+\/[^/]+\/actions\/runs\/[^/]+\/artifacts/;
+const REGEX_IS_ACTIONS_SECRETS_PATH = /^\/repos\/[^/]+\/[^/]+\/actions\/runs\/[^/]+\/artifacts/;
 
 export function normalizePaginatedListResponse(
   octokit: Octokit,
@@ -40,7 +41,8 @@ export function normalizePaginatedListResponse(
     !REGEX_IS_CHECKS_PATH.test(path) &&
     !REGEX_IS_INSTALLATION_REPOSITORIES_PATH.test(path) &&
     !REGEX_IS_USER_INSTALLATIONS_PATH.test(path) &&
-    !REGEX_IS_ACTIONS_ARTIFACTS_PATH.test(path)
+    !REGEX_IS_ACTIONS_ARTIFACTS_PATH.test(path) &&
+    !REGEX_IS_ACTIONS_SECRETS_PATH.test(path)
   ) {
     return;
   }

--- a/src/normalize-paginated-list-response.ts
+++ b/src/normalize-paginated-list-response.ts
@@ -24,14 +24,12 @@ import { Octokit } from "@octokit/core";
 import { OctokitResponse } from "./types";
 
 const REGEX_IS_SEARCH_PATH = /^\/search\//;
-const REGEX_IS_CHECKS_PATH = /^\/repos\/[^/]+\/[^/]+\/commits\/[^/]+\/(check-runs|check-suites)/;
-const REGEX_IS_INSTALLATION_REPOSITORIES_PATH = /^\/installation\/repositories/;
-const REGEX_IS_USER_INSTALLATIONS_PATH = /^\/user\/installations/;
-const REGEX_IS_ACTIONS_ARTIFACTS_PATH = /^\/repos\/[^/]+\/[^/]+\/actions\/runs\/[^/]+\/artifacts/;
-const REGEX_IS_ACTIONS_SECRETS_PATH = /^\/repos\/[^/]+\/[^/]+\/actions\/secrets/;
-const REGEX_IS_ACTIONS_WORKFLOWS_OR_RUNS_PATH = /^\/repos\/[^/]+\/[^/]+\/actions\/workflows/;
-const REGEX_IS_ACTIONS_JOBS_FOR_WORKFLOW_RUN_PATH = /^\/repos\/[^/]+\/[^/]+\/actions\/runs\/[^/]+\/jobs/;
-const REGEX_IS_ACTIONS_WORKFLOW_RUNS_PATH = /^\/repos\/[^/]+\/[^/]+\/actions\/runs/;
+const REGEX_IS_CHECKS_PATH = /^\/repos\/[^/]+\/[^/]+\/commits\/[^/]+\/(check-runs|check-suites)([^/]|$)/;
+const REGEX_IS_INSTALLATION_REPOSITORIES_PATH = /^\/installation\/repositories([^/]|$)/;
+const REGEX_IS_USER_INSTALLATIONS_PATH = /^\/user\/installations([^/]|$)/;
+const REGEX_IS_ACTIONS_SECRETS_PATH = /^\/repos\/[^/]+\/[^/]+\/actions\/secrets([^/]|$)/;
+const REGEX_IS_ACTIONS_WORKFLOWS_PATH = /^\/repos\/[^/]+\/[^/]+\/actions\/workflows(\/[^/]+\/runs)?([^/]|$)/;
+const REGEX_IS_ACTIONS_WORKFLOW_RUNS_PATH = /^\/repos\/[^/]+\/[^/]+\/actions\/runs(\/[^/]+\/(artifacts|jobs))?([^/]|$)/;
 
 export function normalizePaginatedListResponse(
   octokit: Octokit,
@@ -44,10 +42,8 @@ export function normalizePaginatedListResponse(
     !REGEX_IS_CHECKS_PATH.test(path) &&
     !REGEX_IS_INSTALLATION_REPOSITORIES_PATH.test(path) &&
     !REGEX_IS_USER_INSTALLATIONS_PATH.test(path) &&
-    !REGEX_IS_ACTIONS_ARTIFACTS_PATH.test(path) &&
     !REGEX_IS_ACTIONS_SECRETS_PATH.test(path) &&
-    !REGEX_IS_ACTIONS_WORKFLOWS_OR_RUNS_PATH.test(path) &&
-    !REGEX_IS_ACTIONS_JOBS_FOR_WORKFLOW_RUN_PATH.test(path) &&
+    !REGEX_IS_ACTIONS_WORKFLOWS_PATH.test(path) &&
     !REGEX_IS_ACTIONS_WORKFLOW_RUNS_PATH.test(path)
   ) {
     return;

--- a/src/normalize-paginated-list-response.ts
+++ b/src/normalize-paginated-list-response.ts
@@ -29,7 +29,7 @@ const REGEX_IS_INSTALLATION_REPOSITORIES_PATH = /^\/installation\/repositories/;
 const REGEX_IS_USER_INSTALLATIONS_PATH = /^\/user\/installations/;
 const REGEX_IS_ACTIONS_ARTIFACTS_PATH = /^\/repos\/[^/]+\/[^/]+\/actions\/runs\/[^/]+\/artifacts/;
 const REGEX_IS_ACTIONS_SECRETS_PATH = /^\/repos\/[^/]+\/[^/]+\/actions\/secrets/;
-const REGEX_IS_ACTIONS_WORKFLOWS_PATH = /^\/repos\/[^/]+\/[^/]+\/actions\/workflows/;
+const REGEX_IS_ACTIONS_WORKFLOWS_OR_RUNS_PATH = /^\/repos\/[^/]+\/[^/]+\/actions\/workflows/;
 const REGEX_IS_ACTIONS_JOBS_FOR_WORKFLOW_RUN_PATH = /^\/repos\/[^/]+\/[^/]+\/actions\/runs\/[^/]+\/jobs/;
 
 export function normalizePaginatedListResponse(
@@ -45,7 +45,7 @@ export function normalizePaginatedListResponse(
     !REGEX_IS_USER_INSTALLATIONS_PATH.test(path) &&
     !REGEX_IS_ACTIONS_ARTIFACTS_PATH.test(path) &&
     !REGEX_IS_ACTIONS_SECRETS_PATH.test(path) &&
-    !REGEX_IS_ACTIONS_WORKFLOWS_PATH.test(path) &&
+    !REGEX_IS_ACTIONS_WORKFLOWS_OR_RUNS_PATH.test(path) &&
     !REGEX_IS_ACTIONS_JOBS_FOR_WORKFLOW_RUN_PATH.test(path)
   ) {
     return;

--- a/src/normalize-paginated-list-response.ts
+++ b/src/normalize-paginated-list-response.ts
@@ -31,6 +31,7 @@ const REGEX_IS_ACTIONS_ARTIFACTS_PATH = /^\/repos\/[^/]+\/[^/]+\/actions\/runs\/
 const REGEX_IS_ACTIONS_SECRETS_PATH = /^\/repos\/[^/]+\/[^/]+\/actions\/secrets/;
 const REGEX_IS_ACTIONS_WORKFLOWS_OR_RUNS_PATH = /^\/repos\/[^/]+\/[^/]+\/actions\/workflows/;
 const REGEX_IS_ACTIONS_JOBS_FOR_WORKFLOW_RUN_PATH = /^\/repos\/[^/]+\/[^/]+\/actions\/runs\/[^/]+\/jobs/;
+const REGEX_IS_ACTIONS_WORKFLOW_RUNS_PATH = /^\/repos\/[^/]+\/[^/]+\/actions\/runs/;
 
 export function normalizePaginatedListResponse(
   octokit: Octokit,
@@ -46,7 +47,8 @@ export function normalizePaginatedListResponse(
     !REGEX_IS_ACTIONS_ARTIFACTS_PATH.test(path) &&
     !REGEX_IS_ACTIONS_SECRETS_PATH.test(path) &&
     !REGEX_IS_ACTIONS_WORKFLOWS_OR_RUNS_PATH.test(path) &&
-    !REGEX_IS_ACTIONS_JOBS_FOR_WORKFLOW_RUN_PATH.test(path)
+    !REGEX_IS_ACTIONS_JOBS_FOR_WORKFLOW_RUN_PATH.test(path) &&
+    !REGEX_IS_ACTIONS_WORKFLOW_RUNS_PATH.test(path)
   ) {
     return;
   }

--- a/test/paginate.test.ts
+++ b/test/paginate.test.ts
@@ -420,6 +420,25 @@ describe("pagination", () => {
       });
   });
 
+  it.todo(
+    ".paginate() with results namespace (GET /repos/:owner/:repo/actions/runs/:run_id/artifacts)"
+  );
+  it.todo(
+    ".paginate() with results namespace (GET /repos/:owner/:repo/actions/secrets)"
+  );
+  it.todo(
+    ".paginate() with results namespace (GET /repos/:owner/:repo/actions/workflows)"
+  );
+  it.todo(
+    ".paginate() with results namespace (GET /repos/:owner/:repo/actions/runs/:run_id/jobs)"
+  );
+  it.todo(
+    ".paginate() with results namespace (GET /repos/:owner/:repo/actions/workflows/:workflow_id/runs)"
+  );
+  it.todo(
+    ".paginate() with results namespace (GET /repos/:owner/:repo/actions/runs)"
+  );
+
   it(".paginate() with results namespace (GET /installation/repositories, single page response)", () => {
     const result = {
       total_count: 2,

--- a/test/paginate.test.ts
+++ b/test/paginate.test.ts
@@ -670,7 +670,7 @@ describe("pagination", () => {
         expect(results).toStrictEqual([...result1.jobs, ...result2.jobs]);
       });
   });
-  it.only(".paginate() with results namespace (GET /repos/:owner/:repo/actions/workflows/:workflow_id/runs)", () => {
+  it(".paginate() with results namespace (GET /repos/:owner/:repo/actions/workflows/:workflow_id/runs)", () => {
     const result1 = {
       total_count: 2,
       workflow_runs: [
@@ -734,9 +734,69 @@ describe("pagination", () => {
         ]);
       });
   });
-  it.todo(
-    ".paginate() with results namespace (GET /repos/:owner/:repo/actions/runs)"
-  );
+  it(".paginate() with results namespace (GET /repos/:owner/:repo/actions/runs)", () => {
+    const result1 = {
+      total_count: 2,
+      workflow_runs: [
+        {
+          id: "123"
+        }
+      ]
+    };
+    const result2 = {
+      total_count: 2,
+      repository_selection: "all",
+      workflow_runs: [
+        {
+          id: "456"
+        }
+      ]
+    };
+
+    const mock = fetchMock
+      .sandbox()
+      .get(
+        `https://api.github.com/repos/octocat/hello-world/actions/runs?per_page=1`,
+        {
+          body: result1,
+          headers: {
+            link: `<https://api.github.com/repos/octocat/hello-world/actions/runs?per_page=1&page=2>; rel="next"`,
+            "X-GitHub-Media-Type": "github.v3; format=json"
+          }
+        }
+      )
+      .get(
+        `https://api.github.com/repos/octocat/hello-world/actions/runs?per_page=1&page=2`,
+        {
+          body: result2,
+          headers: {
+            link: `<https://api.github.com/repos/octocat/hello-world/actions/runs?per_page=1>; rel="prev", <https://api.github.com/repos/octocat/hello-world/actions/secrets?per_page=1>; rel="first"`,
+            "X-GitHub-Media-Type": "github.v3; format=json"
+          }
+        }
+      );
+
+    const octokit = new TestOctokit({
+      request: {
+        fetch: mock
+      }
+    });
+
+    return octokit
+      .paginate({
+        method: "GET",
+        url: "/repos/:owner/:repo/actions/runs",
+        owner: "octocat",
+        repo: "hello-world",
+        per_page: 1
+      })
+      .then(results => {
+        expect(results).toStrictEqual([
+          ...result1.workflow_runs,
+          ...result2.workflow_runs
+        ]);
+      });
+  });
 
   it(".paginate() with results namespace (GET /installation/repositories, single page response)", () => {
     const result = {

--- a/test/paginate.test.ts
+++ b/test/paginate.test.ts
@@ -609,7 +609,7 @@ describe("pagination", () => {
         ]);
       });
   });
-  it.only(".paginate() with results namespace (GET /repos/:owner/:repo/actions/runs/:run_id/jobs)", () => {
+  it(".paginate() with results namespace (GET /repos/:owner/:repo/actions/runs/:run_id/jobs)", () => {
     const result1 = {
       total_count: 2,
       jobs: [
@@ -670,9 +670,70 @@ describe("pagination", () => {
         expect(results).toStrictEqual([...result1.jobs, ...result2.jobs]);
       });
   });
-  it.todo(
-    ".paginate() with results namespace (GET /repos/:owner/:repo/actions/workflows/:workflow_id/runs)"
-  );
+  it.only(".paginate() with results namespace (GET /repos/:owner/:repo/actions/workflows/:workflow_id/runs)", () => {
+    const result1 = {
+      total_count: 2,
+      workflow_runs: [
+        {
+          id: "123"
+        }
+      ]
+    };
+    const result2 = {
+      total_count: 2,
+      repository_selection: "all",
+      workflow_runs: [
+        {
+          id: "456"
+        }
+      ]
+    };
+
+    const mock = fetchMock
+      .sandbox()
+      .get(
+        `https://api.github.com/repos/octocat/hello-world/actions/workflows/123/runs?per_page=1`,
+        {
+          body: result1,
+          headers: {
+            link: `<https://api.github.com/repos/octocat/hello-world/actions/workflows/123/runs?per_page=1&page=2>; rel="next"`,
+            "X-GitHub-Media-Type": "github.v3; format=json"
+          }
+        }
+      )
+      .get(
+        `https://api.github.com/repos/octocat/hello-world/actions/workflows/123/runs?per_page=1&page=2`,
+        {
+          body: result2,
+          headers: {
+            link: `<https://api.github.com/repos/octocat/hello-world/actions/workflows/123/runs?per_page=1>; rel="prev", <https://api.github.com/repos/octocat/hello-world/actions/secrets?per_page=1>; rel="first"`,
+            "X-GitHub-Media-Type": "github.v3; format=json"
+          }
+        }
+      );
+
+    const octokit = new TestOctokit({
+      request: {
+        fetch: mock
+      }
+    });
+
+    return octokit
+      .paginate({
+        method: "GET",
+        url: "/repos/:owner/:repo/actions/workflows/:workflow_id/runs",
+        owner: "octocat",
+        repo: "hello-world",
+        workflow_id: 123,
+        per_page: 1
+      })
+      .then(results => {
+        expect(results).toStrictEqual([
+          ...result1.workflow_runs,
+          ...result2.workflow_runs
+        ]);
+      });
+  });
   it.todo(
     ".paginate() with results namespace (GET /repos/:owner/:repo/actions/runs)"
   );

--- a/test/paginate.test.ts
+++ b/test/paginate.test.ts
@@ -420,7 +420,7 @@ describe("pagination", () => {
       });
   });
 
-  it.only(".paginate() with results namespace (GET /repos/:owner/:repo/actions/runs/:run_id/artifacts)", () => {
+  it(".paginate() with results namespace (GET /repos/:owner/:repo/actions/runs/:run_id/artifacts)", () => {
     const result1 = {
       total_count: 2,
       artifacts: [
@@ -484,9 +484,68 @@ describe("pagination", () => {
         ]);
       });
   });
-  it.todo(
-    ".paginate() with results namespace (GET /repos/:owner/:repo/actions/secrets)"
-  );
+
+  it.only(".paginate() with results namespace (GET /repos/:owner/:repo/actions/secrets)", () => {
+    const result1 = {
+      total_count: 2,
+      secrets: [
+        {
+          id: "123"
+        }
+      ]
+    };
+    const result2 = {
+      total_count: 2,
+      repository_selection: "all",
+      secrets: [
+        {
+          id: "456"
+        }
+      ]
+    };
+
+    const mock = fetchMock
+      .sandbox()
+      .get(
+        `https://api.github.com/repos/octocat/hello-world/actions/secrets?per_page=1`,
+        {
+          body: result1,
+          headers: {
+            link: `<https://api.github.com/repos/octocat/hello-world/actions/secrets?per_page=1&page=2>; rel="next"`,
+            "X-GitHub-Media-Type": "github.v3; format=json"
+          }
+        }
+      )
+      .get(
+        `https://api.github.com/repos/octocat/hello-world/actions/secrets?per_page=1&page=2`,
+        {
+          body: result2,
+          headers: {
+            link: `<https://api.github.com/repos/octocat/hello-world/actions/secrets?per_page=1>; rel="prev", <https://api.github.com/repos/octocat/hello-world/actions/secrets?per_page=1>; rel="first"`,
+            "X-GitHub-Media-Type": "github.v3; format=json"
+          }
+        }
+      );
+
+    const octokit = new TestOctokit({
+      request: {
+        fetch: mock
+      }
+    });
+
+    return octokit
+      .paginate({
+        method: "GET",
+        url: "/repos/:owner/:repo/actions/secrets",
+        owner: "octocat",
+        repo: "hello-world",
+        per_page: 1
+      })
+      .then(results => {
+        expect(results).toStrictEqual([...result1.secrets, ...result2.secrets]);
+      });
+  });
+
   it.todo(
     ".paginate() with results namespace (GET /repos/:owner/:repo/actions/workflows)"
   );


### PR DESCRIPTION
- [x] https://developer.github.com/v3/actions/artifacts/#list-workflow-run-artifacts
      `GET /repos/:owner/:repo/actions/runs/:run_id/artifacts`, key: `artifacts`
- [x] https://developer.github.com/v3/actions/secrets/#list-secrets-for-a-repository
      `GET /repos/:owner/:repo/actions/secrets`, key: `secrets`
- [x] https://developer.github.com/v3/actions/workflows/#list-repository-workflows
      `GET /repos/:owner/:repo/actions/workflows`, key: `workflows`
- [x] https://developer.github.com/v3/actions/workflow_jobs/#list-jobs-for-a-workflow-run
      `GET /repos/:owner/:repo/actions/runs/:run_id/jobs`, key: `jobs`
- [x] https://developer.github.com/v3/actions/workflow_runs/#list-workflow-runs
      `GET /repos/:owner/:repo/actions/workflows/:workflow_id/runs`, key: `workflow_runs`
- [x] https://developer.github.com/v3/actions/workflow_runs/#list-repository-workflow-runs
      `GET /repos/:owner/:repo/actions/runs`, key: `workflow_runs`