### PR TITLE
fix(package): lower peerDependency on `@octokit/core` to `>=2`

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@octokit/types": "^5.3.0"
   },
   "peerDependencies": {
-    "@octokit/core": ">=3"
+    "@octokit/core": ">=2"
   },
   "devDependencies": {
     "@octokit/core": "^3.0.0",


### PR DESCRIPTION
this still works with @octokit/core version 2. The peerDependencies value of `>=3` is causing a peer dependency warning when downloading the `@octokit/rest` version 17 dependency tree.

@gr2m 