### PR TITLE
fix(typescript): replaced `import type` with `import` to support TypeScript <3.8

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import { iterator } from "./iterator";
 import { PaginateInterface } from "./types";
 export { PaginateInterface } from "./types";
 
-import type { Octokit } from "@octokit/core";
+import { Octokit } from "@octokit/core";
 
 /**
  * @param octokit Octokit instance


### PR DESCRIPTION
https://github.com/octokit/plugin-paginate-rest.js/pull/130#issuecomment-689077360