### PR TITLE
feat(typescript): expose PaginatingEndpoints to user

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { iterator } from "./iterator";
 import { PaginateInterface } from "./types";
 
 export { PaginateInterface } from "./types";
+export { PaginatingEndpoints } from "./types";
 export { composePaginateRest } from "./compose-paginate";
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,8 @@ export {
   Route,
 } from "@octokit/types";
 
+export { PaginatingEndpoints } from "./generated/paginating-endpoints";
+
 import { PaginatingEndpoints } from "./generated/paginating-endpoints";
 
 // // https://stackoverflow.com/a/52991061/206879

--- a/test/validate-typescript.ts
+++ b/test/validate-typescript.ts
@@ -3,7 +3,7 @@
 import { Octokit } from "@octokit/core";
 import { restEndpointMethods } from "@octokit/plugin-rest-endpoint-methods";
 
-import { paginateRest } from "../src";
+import { paginateRest, PaginatingEndpoints } from "../src";
 
 const MyOctokit = Octokit.plugin(paginateRest, restEndpointMethods);
 const octokit = new MyOctokit();
@@ -189,4 +189,10 @@ export async function requestMethodWithNamespacedResponse() {
   for (const result of results) {
     console.log(result.owner.login);
   }
+}
+
+export async function paginatingEndpointKeyProvidedByUser<
+  R extends keyof PaginatingEndpoints
+>(route: R) {
+  console.log(await octokit.paginate(route));
 }


### PR DESCRIPTION
``PaginatingEndpoints`` appears in definition of arguments to ``composePaginateRest``. For most of its overloads (defined in ``ComposePaginateInterface``) the user is able to obtain information about argument types. Sometimes it's just a matter of importing an appropriate type from ``@octokit/types``, in some other cases a relativelly simple type, such as``MapFunction`` has to be redefined in user's code. The ``PaginatingEndpoints`` is an exception, because it's far from being "relativelly simple" . I think it's reasonable to expose this type to users.