### PR TITLE
build: add script to fix `package.json` before publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,8 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run build
+      - name: "Fix pkg.files file pattern"
+        run: node scripts/fix-package-json.js
       - run: npx semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/fix-package-json.js
+++ b/scripts/fix-package-json.js
@@ -1,0 +1,15 @@
+const fs = require("fs");
+const path = require("path");
+const { EOL } = require("os");
+
+const pkgPath = path.join(__dirname, "../pkg/package.json");
+const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8"));
+
+pkg.files = pkg.files.map((file) => {
+  if (file.endsWith("/")) {
+    return file + "**";
+  }
+  return file;
+});
+
+fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + EOL, "utf8");


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->


<!-- Issues are required for both bug fixes and features. -->
Removes one block on #518

----

## Behavior

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->
The released npm package is missing most of the files generated by the build step. `dist-node`, `dist-types`, `dist-web`... even though they are generated correctly.


### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->
With the corrected file patterns, npm will publish all the necessary files again.


### Other information
This is a mix of an issue with `npm@v9` (https://github.com/npm/cli/issues/6164) and the fact we rely on `pika` for the build step. Pika has been archived [since April 2022](https://github.com/FredKSchott/pika-pack) so there is nothing we can do with Pika.

----

## Additional info

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Added the appropriate label for the given change

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/main/community/breaking_changes.md) to help!

- [ ] Yes (Please add the `Type: Breaking change` label)
- [x] No

If `Yes`, what's the impact:

* N/A


### Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please add the corresponding label for change this PR introduces:
- Dependencies/code cleanup: `Type: Maintenance`

----

