### PR TITLE
docs: replace references to Skypack CDN with esm.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,15 +13,15 @@
 Browsers
 </th><td width=100%>
 
-Load `@octokit/plugin-paginate-rest` and [`@octokit/core`](https://github.com/octokit/core.js) (or core-compatible module) directly from [cdn.skypack.dev](https://cdn.skypack.dev)
+Load `@octokit/plugin-paginate-rest` and [`@octokit/core`](https://github.com/octokit/core.js) (or core-compatible module) directly from [esm.sh](https://esm.sh)
 
 ```html
 <script type="module">
-  import { Octokit } from "https://cdn.skypack.dev/@octokit/core";
+  import { Octokit } from "https://esm.sh/@octokit/core";
   import {
     paginateRest,
     composePaginateRest,
-  } from "https://cdn.skypack.dev/@octokit/plugin-paginate-rest";
+  } from "https://esm.sh/@octokit/plugin-paginate-rest";
 </script>
 ```
 


### PR DESCRIPTION
The Skypack CDN is no longer maintained, so we should remove references to it.