### PR TITLE
chore(deps): move `@octokit/tsconfig` to a devDependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,12 @@
       "version": "0.0.0-development",
       "license": "MIT",
       "dependencies": {
-        "@octokit/tsconfig": "^2.0.0",
         "@octokit/types": "^10.0.0"
       },
       "devDependencies": {
         "@octokit/core": "^4.0.0",
         "@octokit/plugin-rest-endpoint-methods": "^7.2.1",
+        "@octokit/tsconfig": "^2.0.0",
         "@types/fetch-mock": "^7.3.1",
         "@types/jest": "^29.0.0",
         "@types/node": "^18.0.0",
@@ -1922,7 +1922,8 @@
     "node_modules/@octokit/tsconfig": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@octokit/tsconfig/-/tsconfig-2.0.0.tgz",
-      "integrity": "sha512-tWnrai3quGt8+gRN2edzo9fmraWekeryXPeXDomMw2oFSpu/lH3VSWGn/q4V+rwjTRMeeXk/ci623/01Zet4VQ=="
+      "integrity": "sha512-tWnrai3quGt8+gRN2edzo9fmraWekeryXPeXDomMw2oFSpu/lH3VSWGn/q4V+rwjTRMeeXk/ci623/01Zet4VQ==",
+      "dev": true
     },
     "node_modules/@octokit/types": {
       "version": "10.0.0",
@@ -9203,7 +9204,8 @@
     "@octokit/tsconfig": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@octokit/tsconfig/-/tsconfig-2.0.0.tgz",
-      "integrity": "sha512-tWnrai3quGt8+gRN2edzo9fmraWekeryXPeXDomMw2oFSpu/lH3VSWGn/q4V+rwjTRMeeXk/ci623/01Zet4VQ=="
+      "integrity": "sha512-tWnrai3quGt8+gRN2edzo9fmraWekeryXPeXDomMw2oFSpu/lH3VSWGn/q4V+rwjTRMeeXk/ci623/01Zet4VQ==",
+      "dev": true
     },
     "@octokit/types": {
       "version": "10.0.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@octokit/tsconfig": "^2.0.0",
     "@octokit/types": "^10.0.0"
   },
   "peerDependencies": {
@@ -34,6 +33,7 @@
   "devDependencies": {
     "@octokit/core": "^4.0.0",
     "@octokit/plugin-rest-endpoint-methods": "^7.2.1",
+    "@octokit/tsconfig": "^2.0.0",
     "@types/fetch-mock": "^7.3.1",
     "@types/jest": "^29.0.0",
     "@types/node": "^18.0.0",


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->


<!-- Issues are required for both bug fixes and features. -->
Resolves #ISSUE_NUMBER

----

## Behavior

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* `@octokit/tsconfig` would always get pulled in

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* `@octokit/tsconfig` is no longer pulled in, it is now marked as a dev dependency


### Other information
<!-- Any other information that is important to this PR  -->

*

----

## Additional info

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Added the appropriate label for the given change

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/main/community/breaking_changes.md) to help!

- [ ] Yes (Please add the `Type: Breaking change` label)
- [x] No

If `Yes`, what's the impact:

* N/A


### Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please add the corresponding label for change this PR introduces:
- Dependencies/code cleanup: `Type: Maintenance`

----

