### PR TITLE
docs: add comment explaining handling of `409 conflict` error

### DIFF
--- a/src/iterator.ts
+++ b/src/iterator.ts
@@ -40,7 +40,7 @@ export function iterator(
 
           return { value: normalizedResponse };
         } catch (error: any) {
-          // `GET /repos/{owner}/{repo}/commits` and throws a `409 Conflict` error for empty repositories
+          // `GET /repos/{owner}/{repo}/commits` throws a `409 Conflict` error for empty repositories
           // See https://github.com/github/rest-api-description/issues/385
           if (error.status !== 409) throw error;
 

--- a/src/iterator.ts
+++ b/src/iterator.ts
@@ -40,6 +40,8 @@ export function iterator(
 
           return { value: normalizedResponse };
         } catch (error: any) {
+          // `GET /repos/{owner}/{repo}/commits` and throws a `409 Conflict` error for empty repositories
+          // See https://github.com/github/rest-api-description/issues/385
           if (error.status !== 409) throw error;
 
           url = "";


### PR DESCRIPTION
Just looked through the code and found this line, I remembered why we put it in and figured we should add a comment for future me that will forget it for sure 👴🏼 