### PR TITLE
refactor: use`node:` specifier imports and full relative path imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint:fix": "prettier --write '{src,test,scripts}/**/*' '!scripts/generated/*' README.md package.json",
     "pretest": "npm run -s lint",
     "test": "jest --coverage",
-    "test:ts": "npx tsc --noEmit --declaration --noUnusedLocals test/validate-typescript.ts",
+    "test:ts": "npx tsc --noEmit --declaration --noUnusedLocals --allowImportingTsExtensions test/validate-typescript.ts",
     "update-endpoints": "npm-run-all update-endpoints:*",
     "update-endpoints:fetch-json": "node scripts/update-endpoints/fetch-json",
     "update-endpoints:typescript": "node scripts/update-endpoints/typescript"
@@ -64,6 +64,9 @@
         "functions": 100,
         "lines": 100
       }
+    },
+    "moduleNameMapper": {
+      "^(.+)\\.jsx?$": "$1"
     }
   },
   "release": {

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -1,6 +1,6 @@
 // @ts-check
 import esbuild from "esbuild";
-import { copyFile, readFile, writeFile, rm } from "fs/promises";
+import { copyFile, readFile, writeFile, rm } from "node:fs/promises";
 import { glob } from "glob";
 
 /**

--- a/src/compose-paginate.ts
+++ b/src/compose-paginate.ts
@@ -1,7 +1,7 @@
-import { paginate } from "./paginate";
-import { iterator } from "./iterator";
+import { paginate } from "./paginate.js";
+import { iterator } from "./iterator.js";
 
-import type { ComposePaginateInterface } from "./types";
+import type { ComposePaginateInterface } from "./types.js";
 
 export const composePaginateRest = Object.assign(paginate, {
   iterator,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,16 +1,16 @@
 import type { Octokit } from "@octokit/core";
 
-import { VERSION } from "./version";
-import { paginate } from "./paginate";
-import { iterator } from "./iterator";
-import type { PaginateInterface } from "./types";
+import { VERSION } from "./version.js";
+import { paginate } from "./paginate.js";
+import { iterator } from "./iterator.js";
+import type { PaginateInterface } from "./types.js";
 
-export type { PaginateInterface, PaginatingEndpoints } from "./types";
-export { composePaginateRest } from "./compose-paginate";
+export type { PaginateInterface, PaginatingEndpoints } from "./types.js";
+export { composePaginateRest } from "./compose-paginate.js";
 export {
   isPaginatingEndpoint,
   paginatingEndpoints,
-} from "./paginating-endpoints";
+} from "./paginating-endpoints.js";
 
 /**
  * @param octokit Octokit instance

--- a/src/iterator.ts
+++ b/src/iterator.ts
@@ -1,12 +1,12 @@
 import type { Octokit } from "@octokit/core";
 
-import { normalizePaginatedListResponse } from "./normalize-paginated-list-response";
+import { normalizePaginatedListResponse } from "./normalize-paginated-list-response.js";
 import type {
   EndpointOptions,
   RequestInterface,
   RequestParameters,
   Route,
-} from "./types";
+} from "./types.js";
 
 export function iterator(
   octokit: Octokit,

--- a/src/normalize-paginated-list-response.ts
+++ b/src/normalize-paginated-list-response.ts
@@ -15,7 +15,7 @@
  * otherwise match: https://developer.github.com/v3/repos/statuses/#get-the-combined-status-for-a-specific-ref
  */
 
-import type { OctokitResponse } from "./types";
+import type { OctokitResponse } from "./types.js";
 
 export function normalizePaginatedListResponse(
   response: OctokitResponse<any>,

--- a/src/paginate.ts
+++ b/src/paginate.ts
@@ -1,6 +1,6 @@
 import type { Octokit } from "@octokit/core";
 
-import { iterator } from "./iterator";
+import { iterator } from "./iterator.js";
 import type {
   MapFunction,
   PaginationResults,

--- a/src/paginating-endpoints.ts
+++ b/src/paginating-endpoints.ts
@@ -1,9 +1,9 @@
 import {
   type PaginatingEndpoints,
   paginatingEndpoints,
-} from "./generated/paginating-endpoints";
+} from "./generated/paginating-endpoints.js";
 
-export { paginatingEndpoints } from "./generated/paginating-endpoints";
+export { paginatingEndpoints } from "./generated/paginating-endpoints.js";
 
 export function isPaginatingEndpoint(
   arg: unknown,

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,9 +9,9 @@ export type {
   Route,
 } from "@octokit/types";
 
-export type { PaginatingEndpoints } from "./generated/paginating-endpoints";
+export type { PaginatingEndpoints } from "./generated/paginating-endpoints.js";
 
-import type { PaginatingEndpoints } from "./generated/paginating-endpoints";
+import type { PaginatingEndpoints } from "./generated/paginating-endpoints.js";
 
 // // https://stackoverflow.com/a/52991061/206879
 // type RequiredKeys<T> = {

--- a/test/compose-paginate.test.ts
+++ b/test/compose-paginate.test.ts
@@ -1,7 +1,7 @@
 import fetchMock from "fetch-mock";
 import { Octokit } from "@octokit/core";
 
-import { composePaginateRest } from "../src";
+import { composePaginateRest } from "../src/index.ts";
 
 const ORG1 = { id: 1 };
 const ORG2 = { id: 2 };

--- a/test/issues.test.ts
+++ b/test/issues.test.ts
@@ -2,7 +2,7 @@ import fetchMock from "fetch-mock";
 import { Octokit } from "@octokit/core";
 import { restEndpointMethods } from "@octokit/plugin-rest-endpoint-methods";
 
-import { paginateRest } from "../src";
+import { paginateRest } from "../src/index.ts";
 
 describe("https://github.com/octokit/plugin-paginate-rest.js/issues/46", () => {
   it("octokit.paginate('GET /projects/columns/{column}/cards', { column })", async () => {

--- a/test/paginate.test.ts
+++ b/test/paginate.test.ts
@@ -2,7 +2,7 @@ import fetchMock from "fetch-mock";
 import { Octokit } from "@octokit/core";
 import { restEndpointMethods } from "@octokit/plugin-rest-endpoint-methods";
 
-import { paginateRest } from "../src";
+import { paginateRest } from "../src/index.ts";
 
 const ORG1 = { id: 1 };
 const ORG2 = { id: 2 };

--- a/test/paginating-endpoints.test.ts
+++ b/test/paginating-endpoints.test.ts
@@ -1,4 +1,4 @@
-import { paginatingEndpoints, isPaginatingEndpoint } from "../src";
+import { paginatingEndpoints, isPaginatingEndpoint } from "../src/index.ts";
 
 describe("paginating endpoints", () => {
   describe.each(paginatingEndpoints.map((arg) => [arg]))(

--- a/test/smoke.test.ts
+++ b/test/smoke.test.ts
@@ -5,7 +5,7 @@ import {
   composePaginateRest,
   isPaginatingEndpoint,
   paginatingEndpoints,
-} from "../src";
+} from "../src/index.ts";
 
 describe("Smoke test", () => {
   it("paginateRest", () => {

--- a/test/tsconfig.test.json
+++ b/test/tsconfig.test.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "emitDeclarationOnly": false,
     "noEmit": true,
-    "verbatimModuleSyntax": false
+    "verbatimModuleSyntax": false,
+    "allowImportingTsExtensions": true
   },
   "include": ["src/**/*"]
 }

--- a/test/validate-typescript.ts
+++ b/test/validate-typescript.ts
@@ -3,7 +3,7 @@
 import { Octokit } from "@octokit/core";
 import { restEndpointMethods } from "@octokit/plugin-rest-endpoint-methods";
 
-import { paginateRest, PaginatingEndpoints } from "../src";
+import { paginateRest, PaginatingEndpoints } from "../src/index.ts";
 
 const MyOctokit = Octokit.plugin(paginateRest, restEndpointMethods);
 const octokit = new MyOctokit();


### PR DESCRIPTION
This PR replaces NodeJS internal module imports with `node:` specifier imports.