### PR TITLE
fix(pkg): add default fallback and types export

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ function myPlugin(octokit, options) {
 }
 ```
 
+As we use [conditional exports](https://nodejs.org/api/packages.html#conditional-exports), you will need to adapt your `tsconfig.json`. See the TypeScript docs on [package.json "exports"](https://www.typescriptlang.org/docs/handbook/modules/reference.html#packagejson-exports).
+
 ## `octokit.paginate()`
 
 The `paginateRest` plugin adds a new `octokit.paginate()` method which accepts the same parameters as [`octokit.request`](https://github.com/octokit/request.js#request). Only "List ..." endpoints such as [List issues for a repository](https://developer.github.com/v3/issues/#list-issues-for-a-repository) are supporting pagination. Their [response includes a Link header](https://developer.github.com/v3/issues/#response-1). For other endpoints, `octokit.paginate()` behaves the same as `octokit.request()`.

--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ function myPlugin(octokit, options) {
 }
 ```
 
-As we use [conditional exports](https://nodejs.org/api/packages.html#conditional-exports), you will need to adapt your `tsconfig.json`. See the TypeScript docs on [package.json "exports"](https://www.typescriptlang.org/docs/handbook/modules/reference.html#packagejson-exports).
+> [!IMPORTANT]
+> As we use [conditional exports](https://nodejs.org/api/packages.html#conditional-exports), you will need to adapt your `tsconfig.json`. See the TypeScript docs on [package.json "exports"](https://www.typescriptlang.org/docs/handbook/modules/reference.html#packagejson-exports).
 
 ## `octokit.paginate()`
 

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -70,6 +70,9 @@ async function main() {
             // Tooling currently are having issues with the "exports" field when there is no "default", ex: TypeScript, eslint
             default: "./dist-bundle/index.js"
           },
+          "./types": {
+            types: "./dist-types/.d.ts",
+          }
         },
         sideEffects: false,
       },

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -62,14 +62,13 @@ async function main() {
       {
         ...pkg,
         files: ["dist-*/**", "bin/**"],
-        // Tooling currently are having issues with the "exports" field, ex: TypeScript, eslint
-        // We add a `main` and `types` field to the package.json for the time being
-        main: "dist-bundle/index.js",
         types: "dist-types/index.d.ts",
         exports: {
           ".": {
             types: "./dist-types/index.d.ts",
             import: "./dist-bundle/index.js",
+            // Tooling currently are having issues with the "exports" field when there is no "default", ex: TypeScript, eslint
+            default: "./dist-bundle/index.js"
           },
         },
         sideEffects: false,

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -68,11 +68,11 @@ async function main() {
             types: "./dist-types/index.d.ts",
             import: "./dist-bundle/index.js",
             // Tooling currently are having issues with the "exports" field when there is no "default", ex: TypeScript, eslint
-            default: "./dist-bundle/index.js"
+            default: "./dist-bundle/index.js",
           },
           "./types": {
             types: "./dist-types/.d.ts",
-          }
+          },
         },
         sideEffects: false,
       },


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->

Resolves octokit/core.js#667 
Resolves octokit/core.js#665

---

### Before the change?

<!-- Please describe the current behavior that you are modifying. -->

- Some consumers of this package could not resolve it properly (ex: `jest`, `ts-node`, `tsx`)
- CJS consumers would be getting errors even though the package is ESM
- Consumers cannot import paths from the package like in CJS

### After the change?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Clients should be able to import the module without any errors with the fallback
- CJS consumers will generate a better error with the new fallback
- Consumers are able to import types from the `dist-types/types.d.ts` file in the package


### Pull request checklist

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?

<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

---
