### PR TITLE
fix(types): improve type extraction for namespaced responses and correct async iterator types

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint:fix": "prettier --write '{src,test,scripts}/**/*' '!scripts/generated/*' README.md package.json",
     "pretest": "npm run -s lint",
     "test": "vitest run --coverage",
-    "test:ts": "npx tsc --noEmit --declaration --noUnusedLocals --allowImportingTsExtensions test/validate-typescript.ts",
+    "test:ts": "npx tsc --noEmit --declaration --noUnusedLocals --allowImportingTsExtensions --strict test/validate-typescript.ts",
     "update-endpoints": "npm-run-all update-endpoints:*",
     "update-endpoints:fetch-json": "node scripts/update-endpoints/fetch-json",
     "update-endpoints:typescript": "node scripts/update-endpoints/typescript"

--- a/src/iterator.ts
+++ b/src/iterator.ts
@@ -58,5 +58,5 @@ export function iterator(
         }
       },
     }),
-  };
+  } as AsyncIterable<any>;
 }

--- a/src/paginate.ts
+++ b/src/paginate.ts
@@ -23,9 +23,7 @@ export function paginate(
   return gather(
     octokit,
     [],
-    iterator(octokit, route, parameters)[
-      Symbol.asyncIterator
-    ]() as AsyncIterableIterator<any>,
+    iterator(octokit, route, parameters)[Symbol.asyncIterator](),
     mapFn,
   );
 }
@@ -33,7 +31,7 @@ export function paginate(
 function gather(
   octokit: Octokit,
   results: PaginationResults,
-  iterator: AsyncIterableIterator<any>,
+  iterator: AsyncIterator<any>,
   mapFn?: MapFunction,
 ): Promise<PaginationResults> {
   return iterator.next().then((result) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,6 +35,7 @@ type KnownKeys<T> = Extract<
   } extends { [_ in keyof T]: infer U }
     ? U
     : never,
+  // Exclude keys that are known to not contain the data
   Exclude<
     keyof T,
     "repository_selection" | "total_count" | "incomplete_results"

--- a/src/types.ts
+++ b/src/types.ts
@@ -199,7 +199,7 @@ export interface PaginateInterface {
      */
     <T>(
       options: OctokitTypes.EndpointOptions,
-    ): AsyncIterableIterator<
+    ): AsyncIterable<
       OctokitTypes.OctokitResponse<PaginationResults<T>>
     >;
 
@@ -215,7 +215,7 @@ export interface PaginateInterface {
     <R extends keyof PaginatingEndpoints>(
       route: R,
       parameters?: PaginatingEndpoints[R]["parameters"],
-    ): AsyncIterableIterator<
+    ): AsyncIterable<
       OctokitTypes.OctokitResponse<DataType<PaginatingEndpoints[R]["response"]>>
     >;
 
@@ -231,7 +231,7 @@ export interface PaginateInterface {
       parameters?: R extends keyof PaginatingEndpoints
         ? PaginatingEndpoints[R]["parameters"]
         : OctokitTypes.RequestParameters,
-    ): AsyncIterableIterator<
+    ): AsyncIterable<
       OctokitTypes.OctokitResponse<PaginationResults<T>>
     >;
 
@@ -247,7 +247,7 @@ export interface PaginateInterface {
     <R extends OctokitTypes.RequestInterface>(
       request: R,
       parameters?: Parameters<R>[0],
-    ): AsyncIterableIterator<
+    ): AsyncIterable<
       NormalizeResponse<OctokitTypes.GetResponseTypeFromEndpointMethod<R>>
     >;
   };
@@ -414,7 +414,7 @@ export interface ComposePaginateInterface {
     <T>(
       octokit: Octokit,
       options: OctokitTypes.EndpointOptions,
-    ): AsyncIterableIterator<
+    ): AsyncIterable<
       OctokitTypes.OctokitResponse<PaginationResults<T>>
     >;
 
@@ -433,7 +433,7 @@ export interface ComposePaginateInterface {
       octokit: Octokit,
       route: R,
       parameters?: PaginatingEndpoints[R]["parameters"],
-    ): AsyncIterableIterator<
+    ): AsyncIterable<
       OctokitTypes.OctokitResponse<DataType<PaginatingEndpoints[R]["response"]>>
     >;
 
@@ -452,7 +452,7 @@ export interface ComposePaginateInterface {
       parameters?: R extends keyof PaginatingEndpoints
         ? PaginatingEndpoints[R]["parameters"]
         : OctokitTypes.RequestParameters,
-    ): AsyncIterableIterator<
+    ): AsyncIterable<
       OctokitTypes.OctokitResponse<PaginationResults<T>>
     >;
 
@@ -471,7 +471,7 @@ export interface ComposePaginateInterface {
       octokit: Octokit,
       request: R,
       parameters?: Parameters<R>[0],
-    ): AsyncIterableIterator<
+    ): AsyncIterable<
       NormalizeResponse<OctokitTypes.GetResponseTypeFromEndpointMethod<R>>
     >;
   };

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,7 +35,10 @@ type KnownKeys<T> = Extract<
   } extends { [_ in keyof T]: infer U }
     ? U
     : never,
-  keyof T
+  Exclude<
+    keyof T,
+    "repository_selection" | "total_count" | "incomplete_results"
+  >
 >;
 type KeysMatching<T, V> = {
   [K in keyof T]: T[K] extends V ? K : never;

--- a/src/types.ts
+++ b/src/types.ts
@@ -199,9 +199,7 @@ export interface PaginateInterface {
      */
     <T>(
       options: OctokitTypes.EndpointOptions,
-    ): AsyncIterable<
-      OctokitTypes.OctokitResponse<PaginationResults<T>>
-    >;
+    ): AsyncIterable<OctokitTypes.OctokitResponse<PaginationResults<T>>>;
 
     // Using route string as first parameter
 
@@ -231,9 +229,7 @@ export interface PaginateInterface {
       parameters?: R extends keyof PaginatingEndpoints
         ? PaginatingEndpoints[R]["parameters"]
         : OctokitTypes.RequestParameters,
-    ): AsyncIterable<
-      OctokitTypes.OctokitResponse<PaginationResults<T>>
-    >;
+    ): AsyncIterable<OctokitTypes.OctokitResponse<PaginationResults<T>>>;
 
     // Using request method as first parameter
 
@@ -414,9 +410,7 @@ export interface ComposePaginateInterface {
     <T>(
       octokit: Octokit,
       options: OctokitTypes.EndpointOptions,
-    ): AsyncIterable<
-      OctokitTypes.OctokitResponse<PaginationResults<T>>
-    >;
+    ): AsyncIterable<OctokitTypes.OctokitResponse<PaginationResults<T>>>;
 
     // Using route string as first parameter
 
@@ -452,9 +446,7 @@ export interface ComposePaginateInterface {
       parameters?: R extends keyof PaginatingEndpoints
         ? PaginatingEndpoints[R]["parameters"]
         : OctokitTypes.RequestParameters,
-    ): AsyncIterable<
-      OctokitTypes.OctokitResponse<PaginationResults<T>>
-    >;
+    ): AsyncIterable<OctokitTypes.OctokitResponse<PaginationResults<T>>>;
 
     // Using request method as first parameter
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -55,7 +55,7 @@ type GetResultsType<T> = T extends { data: any[] }
     : never;
 
 // Ensure that the type always returns the paginated results and not a mix of paginated results and the response object
-type NormalizeResponse<T> = Omit<T, 'data'> & { data: GetResultsType<T> };
+type NormalizeResponse<T> = Omit<T, "data"> & { data: GetResultsType<T> };
 
 type DataType<T> = "data" extends keyof T ? T["data"] : unknown;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -54,7 +54,8 @@ type GetResultsType<T> = T extends { data: any[] }
     ? T["data"][KnownKeysMatching<T["data"], any[]>]
     : never;
 
-type NormalizeResponse<T> = T & { data: GetResultsType<T> };
+// Ensure that the type always returns the paginated results and not a mix of paginated results and the response object
+type NormalizeResponse<T> = Omit<T, 'data'> & { data: GetResultsType<T> };
 
 type DataType<T> = "data" extends keyof T ? T["data"] : unknown;
 


### PR DESCRIPTION
The `iterator()` function returns an object containing a key of `Symbol.asyncIterator`, which is an object with a `next()` function. Only the top-level has the `Symbol.asyncIterator`, and the `next()` function is not present at the top-level

The `GetResultsType<T>` sometimes doesn't return the paginated data and returns the whole data object. For some reason TypeScript sometimes get's confused and returns all the keys in the object in the call `KnownKeysMatching<T["data"], any[]>`
In order to remedy that, we remove keys that we know do not contain the data (`"repository_selection" | "total_count" | "incomplete_results"`) and we then always get the data.

The `NormalizeResponse<T>` type would return the intersection of the original data from the request and the paginated data. To remedy that, we use `Omit<T, K>` to remove the `data` from the request data and only return the paginated data instead.

<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #350

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* Contained wrong types for the return value regarding AsyncIterator
* The `GetResultsType<T>` wouldn't always get the key with the data

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Corrects the types for `AsyncIterator` vs `AsyncIterableIterator`
* The `GetResultsType<T>` correctly gets the pagination data

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No
While not strictly a breaking change, it can cause breakage to end users as the types have changed.

----

