### PR TITLE
fix(types): add back the pagination keys

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -54,9 +54,23 @@ type GetResultsType<T> = T extends { data: any[] }
     ? T["data"][KnownKeysMatching<T["data"], any[]>]
     : never;
 
-// Ensure that the type always returns the paginated results and not a mix of paginated results and the response object
-type NormalizeResponse<T> = Omit<T, "data"> & { data: GetResultsType<T> };
+// Extract the pagination keys from the response object in order to return them alongside the paginated results
+type GetPaginationKeys<T> = T extends { data: any[] }
+  ? T
+  : T extends { data: object }
+    ? Pick<
+        T["data"],
+        Extract<
+          keyof T["data"],
+          "repository_selection" | "total_count" | "incomplete_results"
+        >
+      >
+    : never;
 
+// Ensure that the type always returns the paginated results and not a mix of paginated results and the response object
+type NormalizeResponse<T> = Omit<T, "data"> & {
+  data: GetResultsType<T> & GetPaginationKeys<T>;
+};
 type DataType<T> = "data" extends keyof T ? T["data"] : unknown;
 
 export interface MapFunction<


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #652

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* The types didn't include the `total_count` property

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* The types now contain the `total_count` property

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

