### PR TITLE
fix(types): correct pagination return type for data which is an array

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -28,7 +28,10 @@ import type { PaginatingEndpoints } from "./generated/paginating-endpoints.js";
 //     : never
 //   : never;
 
-type PaginationMetadataKeys = "repository_selection" | "total_count" | "incomplete_results";
+type PaginationMetadataKeys =
+  | "repository_selection"
+  | "total_count"
+  | "incomplete_results";
 
 // https://stackoverflow.com/a/58980331/206879
 type KnownKeys<T> = Extract<
@@ -38,10 +41,7 @@ type KnownKeys<T> = Extract<
     ? U
     : never,
   // Exclude keys that are known to not contain the data
-  Exclude<
-    keyof T,
-    PaginationMetadataKeys
-  >
+  Exclude<keyof T, PaginationMetadataKeys>
 >;
 type KeysMatching<T, V> = {
   [K in keyof T]: T[K] extends V ? K : never;
@@ -60,13 +60,7 @@ type GetResultsType<T> = T extends { data: any[] }
 type GetPaginationKeys<T> = T extends { data: any[] }
   ? {}
   : T extends { data: object }
-    ? Pick<
-        T["data"],
-        Extract<
-          keyof T["data"],
-          PaginationMetadataKeys
-        >
-      >
+    ? Pick<T["data"], Extract<keyof T["data"], PaginationMetadataKeys>>
     : never;
 
 // Ensure that the type always returns the paginated results and not a mix of paginated results and the response object

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,6 +28,8 @@ import type { PaginatingEndpoints } from "./generated/paginating-endpoints.js";
 //     : never
 //   : never;
 
+type PaginationMetadataKeys = "repository_selection" | "total_count" | "incomplete_results";
+
 // https://stackoverflow.com/a/58980331/206879
 type KnownKeys<T> = Extract<
   {
@@ -38,7 +40,7 @@ type KnownKeys<T> = Extract<
   // Exclude keys that are known to not contain the data
   Exclude<
     keyof T,
-    "repository_selection" | "total_count" | "incomplete_results"
+    PaginationMetadataKeys
   >
 >;
 type KeysMatching<T, V> = {
@@ -56,13 +58,13 @@ type GetResultsType<T> = T extends { data: any[] }
 
 // Extract the pagination keys from the response object in order to return them alongside the paginated results
 type GetPaginationKeys<T> = T extends { data: any[] }
-  ? T
+  ? {}
   : T extends { data: object }
     ? Pick<
         T["data"],
         Extract<
           keyof T["data"],
-          "repository_selection" | "total_count" | "incomplete_results"
+          PaginationMetadataKeys
         >
       >
     : never;

--- a/test/validate-typescript.ts
+++ b/test/validate-typescript.ts
@@ -197,9 +197,12 @@ export async function requestMethodWithNamespacedResponse() {
 
 // https://github.com/octokit/plugin-paginate-rest.js/issues/661
 // Ensure the endpoints that return an array don't have an extra `OctokitResponse` in the data
-type Package = PaginatingEndpoints["GET /orgs/{org}/packages/{package_type}/{package_name}/versions"]["response"]["data"][0];
+type Package =
+  PaginatingEndpoints["GET /orgs/{org}/packages/{package_type}/{package_name}/versions"]["response"]["data"][0];
 export async function requestWithArrayResponse() {
-  const results = await octokit.paginate("GET /orgs/{org}/packages/{package_type}/{package_name}/versions");
+  const results = await octokit.paginate(
+    "GET /orgs/{org}/packages/{package_type}/{package_name}/versions",
+  );
   for (const result of results) {
     const pkg: Package = result;
     console.log(pkg.name);

--- a/test/validate-typescript.ts
+++ b/test/validate-typescript.ts
@@ -195,6 +195,17 @@ export async function requestMethodWithNamespacedResponse() {
   }
 }
 
+// https://github.com/octokit/plugin-paginate-rest.js/issues/661
+// Ensure the endpoints that return an array don't have an extra `OctokitResponse` in the data
+type Package = PaginatingEndpoints["GET /orgs/{org}/packages/{package_type}/{package_name}/versions"]["response"]["data"][0];
+export async function requestWithArrayResponse() {
+  const results = await octokit.paginate("GET /orgs/{org}/packages/{package_type}/{package_name}/versions");
+  for (const result of results) {
+    const pkg: Package = result;
+    console.log(pkg.name);
+  }
+}
+
 export async function paginatingEndpointKeyProvidedByUser<
   R extends keyof PaginatingEndpoints,
 >(route: R) {


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #661

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* When response data from GitHub is an array, the type would have an extra `OctokitResponse<T, S>` in the data types

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* When response data from GitHub is an array, return an empty object in the types

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

