### PR TITLE
ci: use `lts/*` version instead of pinning to Node 16

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           cache: npm
-          node-version: 16
+          node-version: lts/*
       - run: git checkout routes-update || true
       - run: npm install @octokit/types@latest
         if: >-


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #ISSUE_NUMBER

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* Would use Node 16 for the update workflow

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Uses the latest LTS release of Node instead of being pinned to a specific version

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [ ] No

----

