### PR TITLE
ci: replace `OCTOKITBOT_PROJECT_ACTION_TOKEN` and `OCTOKITBOT_PAT` with a token from https://github.com/apps/octokit

### DIFF
--- a/.github/workflows/add_to_octokit_project.yml
+++ b/.github/workflows/add_to_octokit_project.yml
@@ -12,9 +12,14 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
+      - uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ vars.OCTOKIT_APP_ID }}
+          private-key: ${{ secrets.OCTOKIT_APP_PRIVATE_KEY }}
       - uses: actions/add-to-project@v1.0.2
         with:
           project-url: https://github.com/orgs/octokit/projects/10
-          github-token: ${{ secrets.OCTOKITBOT_PROJECT_ACTION_TOKEN }}
+          github-token: ${{ steps.app-token.outputs.token }}
           labeled: "Status: Stale"
           label-operator: NOT

--- a/.github/workflows/immediate-response.yml
+++ b/.github/workflows/immediate-response.yml
@@ -11,7 +11,7 @@ on:
       - opened
 jobs:
   respond-to-issue:
-    if: ${{ github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]' && github.actor != 'githubactions[bot]' && github.actor != 'octokitbot' }}
+    if: ${{ github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]' && github.actor != 'githubactions[bot]' && github.actor != 'octokitbot' && github.actor != 'octokit[bot]' }}
     runs-on: ubuntu-latest
     steps:
       - name: Determine issue or PR number

--- a/.github/workflows/update-prettier.yml
+++ b/.github/workflows/update-prettier.yml
@@ -7,16 +7,21 @@ jobs:
   update_prettier:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ vars.OCTOKIT_APP_ID }}
+          private-key: ${{ secrets.OCTOKIT_APP_PRIVATE_KEY }}
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           cache: npm
-          node-version: 16
+          node-version: lts/*
       - run: npm ci
       - run: npm run lint:fix
       - uses: gr2m/create-or-update-pull-request-action@v1.x
         env:
-          GITHUB_TOKEN: ${{ secrets.OCTOKITBOT_PAT }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
           title: Prettier updated
           body: An update to prettier required updates to your code.

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -13,9 +13,14 @@ jobs:
   update_routes:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ vars.OCTOKIT_APP_ID }}
+          private-key: ${{ secrets.OCTOKIT_APP_PRIVATE_KEY }}
       - uses: actions/checkout@v4
         with:
-          token: ${{ secrets.OCTOKITBOT_PAT }}
+          token: ${{ steps.app-token.outputs.token }}
       - uses: actions/setup-node@v4
         with:
           cache: npm
@@ -53,7 +58,7 @@ jobs:
       - name: Create Pull Request
         uses: gr2m/create-or-update-pull-request-action@v1.x
         env:
-          GITHUB_TOKEN: ${{ secrets.OCTOKITBOT_PAT }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
           title: 🚧 GitHub OpenAPI specifications changed
           body: >


### PR DESCRIPTION
**Unblocks updates to this repository**
Apply changes from https://github.com/octokit/endpoint.js/pull/482

Part of https://github.com/octokit/maintainers/issues/34
