### PR TITLE
feat: Paginate compareCommits and compareCommitsWithBasehead

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ Most of GitHub's paginating REST API endpoints return an array, but there are a 
 - [List check suites for a specific ref](https://developer.github.com/v3/checks/suites/#response-1) (key: `check_suites`)
 - [List repositories](https://developer.github.com/v3/apps/installations/#list-repositories) for an installation (key: `repositories`)
 - [List installations for a user](https://developer.github.com/v3/apps/installations/#response-1) (key `installations`)
+- [Compare commits](https://docs.github.com/en/rest/commits/commits?apiVersion=2022-11-28#compare-two-commits) (key `commits`)
 
 `octokit.paginate()` is working around these inconsistencies so you don't have to worry about it.
 

--- a/scripts/update-endpoints/typescript.js
+++ b/scripts/update-endpoints/typescript.js
@@ -28,11 +28,6 @@ const ENDPOINTS_WITH_PER_PAGE_ATTRIBUTE_THAT_BEHAVE_DIFFERENTLY = [
   // Only the `files` key inside the commit is paginated. The rest is duplicated across
   // all pages. Handling this case properly requires custom code.
   { scope: "repos", id: "get-commit" },
-  // The [docs](https://docs.github.com/en/rest/commits/commits#compare-two-commits) make
-  // these ones sound like a special case too - they must be because they support pagination
-  // but doesn't return an array.
-  { scope: "repos", id: "compare-commits" },
-  { scope: "repos", id: "compare-commits-with-basehead" },
 ];
 
 const hasMatchingEndpoint = (list, id, scope) =>

--- a/src/generated/paginating-endpoints.ts
+++ b/src/generated/paginating-endpoints.ts
@@ -1196,6 +1196,26 @@ export interface PaginatingEndpoints {
   };
 
   /**
+   * @see https://docs.github.com/rest/commits/commits#compare-two-commits
+   */
+  "GET /repos/{owner}/{repo}/compare/{basehead}": {
+    parameters: Endpoints["GET /repos/{owner}/{repo}/compare/{basehead}"]["parameters"];
+    response: Endpoints["GET /repos/{owner}/{repo}/compare/{basehead}"]["response"] & {
+      data: Endpoints["GET /repos/{owner}/{repo}/compare/{basehead}"]["response"]["data"]["commits"];
+    };
+  };
+
+  /**
+   * @see https://docs.github.com/rest/reference/repos#compare-two-commits
+   */
+  "GET /repos/{owner}/{repo}/compare/{base}...{head}": {
+    parameters: Endpoints["GET /repos/{owner}/{repo}/compare/{base}...{head}"]["parameters"];
+    response: Endpoints["GET /repos/{owner}/{repo}/compare/{base}...{head}"]["response"] & {
+      data: Endpoints["GET /repos/{owner}/{repo}/compare/{base}...{head}"]["response"]["data"]["commits"];
+    };
+  };
+
+  /**
    * @see https://docs.github.com/rest/repos/repos#list-repository-contributors
    */
   "GET /repos/{owner}/{repo}/contributors": {
@@ -2325,6 +2345,8 @@ export const paginatingEndpoints: (keyof PaginatingEndpoints)[] = [
   "GET /repos/{owner}/{repo}/commits/{ref}/check-suites",
   "GET /repos/{owner}/{repo}/commits/{ref}/status",
   "GET /repos/{owner}/{repo}/commits/{ref}/statuses",
+  "GET /repos/{owner}/{repo}/compare/{basehead}",
+  "GET /repos/{owner}/{repo}/compare/{base}...{head}",
   "GET /repos/{owner}/{repo}/contributors",
   "GET /repos/{owner}/{repo}/dependabot/alerts",
   "GET /repos/{owner}/{repo}/dependabot/secrets",

--- a/src/iterator.ts
+++ b/src/iterator.ts
@@ -44,6 +44,7 @@ export function iterator(
             const parsedUrl = new URL(normalizedResponse.url);
             const params = parsedUrl.searchParams;
             const page = parseInt(params.get("page") || "1", 10);
+            /* v8 ignore next */
             const per_page = parseInt(params.get("per_page") || "250", 10);
             if (page * per_page < normalizedResponse.data.total_commits) {
               params.set("page", String(page + 1));

--- a/src/iterator.ts
+++ b/src/iterator.ts
@@ -43,10 +43,10 @@ export function iterator(
           if (!url && "total_commits" in normalizedResponse.data) {
             const parsedUrl = new URL(normalizedResponse.url);
             const params = parsedUrl.searchParams;
-            const page = parseInt(params.get('page') || '1', 10)
-            const per_page = parseInt(params.get('per_page') || '250', 10);
+            const page = parseInt(params.get("page") || "1", 10);
+            const per_page = parseInt(params.get("per_page") || "250", 10);
             if (page * per_page < normalizedResponse.data.total_commits) {
-              params.set('page', String(page + 1));
+              params.set("page", String(page + 1));
               url = parsedUrl.toString();
             }
           }

--- a/src/iterator.ts
+++ b/src/iterator.ts
@@ -40,6 +40,17 @@ export function iterator(
             /<([^<>]+)>;\s*rel="next"/,
           ) || [])[1];
 
+          if (!url && "total_commits" in normalizedResponse.data) {
+            const parsedUrl = new URL(normalizedResponse.url);
+            const params = parsedUrl.searchParams;
+            const page = parseInt(params.get('page') || '1', 10)
+            const per_page = parseInt(params.get('per_page') || '250', 10);
+            if (page * per_page < normalizedResponse.data.total_commits) {
+              params.set('page', String(page + 1));
+              url = parsedUrl.toString();
+            }
+          }
+
           return { value: normalizedResponse };
         } catch (error: any) {
           // `GET /repos/{owner}/{repo}/commits` throws a `409 Conflict` error for empty repositories

--- a/src/normalize-paginated-list-response.ts
+++ b/src/normalize-paginated-list-response.ts
@@ -28,7 +28,7 @@ export function normalizePaginatedListResponse(
     };
   }
   const responseNeedsNormalization =
-    "total_count" in response.data && !("url" in response.data);
+      ("total_count" in response.data && !("url" in response.data)) || "total_commits" in response.data;
   if (!responseNeedsNormalization) return response;
 
   // keep the additional properties intact as there is currently no other way
@@ -36,9 +36,11 @@ export function normalizePaginatedListResponse(
   const incompleteResults = response.data.incomplete_results;
   const repositorySelection = response.data.repository_selection;
   const totalCount = response.data.total_count;
+  const totalCommits = response.data.total_commits;
   delete response.data.incomplete_results;
   delete response.data.repository_selection;
   delete response.data.total_count;
+  delete response.data.total_commits;
 
   const namespaceKey = Object.keys(response.data)[0];
   const data = response.data[namespaceKey];
@@ -53,5 +55,6 @@ export function normalizePaginatedListResponse(
   }
 
   response.data.total_count = totalCount;
+  response.data.total_commits = totalCommits;
   return response;
 }

--- a/src/normalize-paginated-list-response.ts
+++ b/src/normalize-paginated-list-response.ts
@@ -28,7 +28,8 @@ export function normalizePaginatedListResponse(
     };
   }
   const responseNeedsNormalization =
-      ("total_count" in response.data && !("url" in response.data)) || "total_commits" in response.data;
+    ("total_count" in response.data && !("url" in response.data)) ||
+    "total_commits" in response.data;
   if (!responseNeedsNormalization) return response;
 
   // keep the additional properties intact as there is currently no other way

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,6 +31,7 @@ import type { PaginatingEndpoints } from "./generated/paginating-endpoints.js";
 type PaginationMetadataKeys =
   | "repository_selection"
   | "total_count"
+  | "total_commits"
   | "incomplete_results";
 
 // https://stackoverflow.com/a/58980331/206879

--- a/test/issues.test.ts
+++ b/test/issues.test.ts
@@ -77,7 +77,7 @@ describe("https://github.com/octokit/plugin-paginate-rest.js/issues/647", () => 
           body: {
             commits: [{ sha: "commit3" }],
           },
-          headers: {}, // omit link header  
+          headers: {}, // omit link header
         },
       );
 

--- a/test/paginate.test.ts
+++ b/test/paginate.test.ts
@@ -998,6 +998,63 @@ describe("pagination", () => {
         ]);
       });
   });
+
+  it(".paginate() with results namespace (GET /repos/{owner}/{repo}/compare/{basehead})", () => {
+    const result1 = {
+      total_commits: 2,
+      commits: [
+        {
+          sha: "f3b573e4d60a079d154018d2e2d04aff4d26fc41",
+        },
+      ],
+    };
+    const result2 = {
+      total_commits: 2,
+      commits: [
+        {
+          sha: "a740e83052aea45a4cbcdf2954a3a9e47b5d530d",
+        },
+      ],
+    };
+
+    const mock = fetchMock
+      .createInstance()
+      .get(
+        'https://api.github.com/repos/octocat/hello-world/compare/1.0.0...1.0.1?per_page=1',
+        {
+          body: result1,
+        },
+      )
+      .get(
+          'https://api.github.com/repos/octocat/hello-world/compare/1.0.0...1.0.1?per_page=1&page=2',
+        {
+          body: result2,
+        },
+      );
+
+    const octokit = new TestOctokit({
+      request: {
+        fetch: mock.fetchHandler,
+      },
+    });
+
+    return octokit
+      .paginate({
+        method: "GET",
+        url: "/repos/{owner}/{repo}/compare/{basehead}",
+        owner: "octocat",
+        repo: "hello-world",
+        basehead: "1.0.0...1.0.1",
+        per_page: 1,
+      })
+      .then((results) => {
+        expect(results).toEqual([
+          ...result1.commits,
+          ...result2.commits,
+        ]);
+      });
+  });
+
   it(".paginate() with results namespace (GET /repos/{owner}/{repo}/actions/runs)", () => {
     const result1 = {
       total_count: 2,

--- a/test/paginate.test.ts
+++ b/test/paginate.test.ts
@@ -1020,13 +1020,13 @@ describe("pagination", () => {
     const mock = fetchMock
       .createInstance()
       .get(
-        'https://api.github.com/repos/octocat/hello-world/compare/1.0.0...1.0.1?per_page=1',
+        "https://api.github.com/repos/octocat/hello-world/compare/1.0.0...1.0.1?per_page=1",
         {
           body: result1,
         },
       )
       .get(
-          'https://api.github.com/repos/octocat/hello-world/compare/1.0.0...1.0.1?per_page=1&page=2',
+        "https://api.github.com/repos/octocat/hello-world/compare/1.0.0...1.0.1?per_page=1&page=2",
         {
           body: result2,
         },
@@ -1048,10 +1048,7 @@ describe("pagination", () => {
         per_page: 1,
       })
       .then((results) => {
-        expect(results).toEqual([
-          ...result1.commits,
-          ...result2.commits,
-        ]);
+        expect(results).toEqual([...result1.commits, ...result2.commits]);
       });
   });
 


### PR DESCRIPTION
Resolves #647
----

### Before the change?

* `compareCommits` and `compareCommitsWithBasehead` are not correctly paginated.

### After the change?

* `compareCommits` and `compareCommitsWithBasehead` are paginated

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
No breaking changes (unless someone is using paginate with `compareCommits`, which doesn't work).

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [x] Yes
- [ ] No

----

