### PR TITLE
fix: handle url in response when using pagination with compareCommits

### DIFF
--- a/src/normalize-paginated-list-response.ts
+++ b/src/normalize-paginated-list-response.ts
@@ -27,7 +27,9 @@ export function normalizePaginatedListResponse(
       data: [],
     };
   }
-  const responseNeedsNormalization = ("total_count" in response.data || "total_commits" in response.data) && !("url" in response.data);
+  const responseNeedsNormalization =
+    ("total_count" in response.data || "total_commits" in response.data) &&
+    !("url" in response.data);
   if (!responseNeedsNormalization) return response;
 
   // keep the additional properties intact as there is currently no other way

--- a/src/normalize-paginated-list-response.ts
+++ b/src/normalize-paginated-list-response.ts
@@ -27,9 +27,7 @@ export function normalizePaginatedListResponse(
       data: [],
     };
   }
-  const responseNeedsNormalization =
-    ("total_count" in response.data && !("url" in response.data)) ||
-    "total_commits" in response.data;
+  const responseNeedsNormalization = ("total_count" in response.data || "total_commits" in response.data) && !("url" in response.data);
   if (!responseNeedsNormalization) return response;
 
   // keep the additional properties intact as there is currently no other way


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves N/A

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

Trying to use paginate with the `compareCommitsWithBaseHead` endpoint returns the following error:
```
 response.data.total_count = totalCount;
                            ^
TypeError: Cannot create property 'total_count' on string 'https://api.github.com/repos/danger/danger-js/compare/43dde820b424cf11d65e2c42c27b916e162f440a...bdccecb77e0144055fbaea9224f10cf8b1229b68'
    at normalizePaginatedListResponse (Directory/node_modules/@octokit/plugin-paginate-rest/dist-bundle/index.js:33:29)
    at Object.next (Directory/node_modules/@octokit/plugin-paginate-rest/dist-bundle/index.js:51:38)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async nextData (Directory/test.mjs:16:16)
    at async Directory/test.mjs:25:1
```

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->
Pagination for those endpoints and other endpoints continues to work as expected.
![image](https://github.com/user-attachments/assets/f4993cad-ad2d-4ef8-ad2e-4d7be8d50485)


### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [ ] No

----

