### PR TITLE
fix(security): mitigate potential ReDoS in link header regex (2.x)

### DIFF
--- a/src/iterator.ts
+++ b/src/iterator.ts
@@ -35,7 +35,7 @@ export function iterator(
           // '<https://api.github.com/users/aseemk/followers?page=2>; rel="next", <https://api.github.com/users/aseemk/followers?page=2>; rel="last"'
           // sets `url` to undefined if "next" URL is not present or `link` header is not set
           url = ((normalizedResponse.headers.link || "").match(
-            /<([^>]+)>;\s*rel="next"/
+            /<([^<>]+)>;\s*rel="next"/
           ) || [])[1];
 
           return { value: normalizedResponse };


### PR DESCRIPTION
Link header parsing regex is currently a bit too loose, making it prone to backtracking issues. Replacing [^>]+ with [^<>]+ to keep it focused. Just backporting this to 2.x since it's a quick win for performance/stability.